### PR TITLE
Note friendly_id conflict in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ It currently works with ActiveRecord 4.2.x through 6.0.x. If you need support
 for ActiveRecord 3.x, use a pre-1.0 version of the gem, or ActiveRecord < 4.2
 use a pre-2.0 version of the gem.
 
+## Conflicts
+
+This gem produces known conflicts with these other gems:
+
+### friendly_id
+
+When using [friendly_id](https://github.com/norman/friendly_id) >= 5.2.5 with the [History module](https://norman.github.io/friendly_id/FriendlyId/History.html) enabled, duplicate slugs will be generated for STI subclasses with the same sluggable identifier (ex: name). This will either cause saves to fail if you have the proper indexes in place, or will cause slug lookups to be non-deterministic, either of which is undesirable.
+
 ## Copyright
 
 Copyright (c) 2011-2019 AppFolio, inc. See LICENSE.txt for


### PR DESCRIPTION
I discovered a conflict with friendly_id that I thought should be documented here. I haven't found a workaround, and am in the process of removing this gem from my app. I was able to narrow it down to [this change](https://github.com/norman/friendly_id/pull/877/files#diff-1ad7548dd243d3e08c04614a8d48b548R113) in friendly_id, but I haven't found a viable workaround (and don't just want to revert to the old code in a fork). Just noting that here in case anyone wants to dig any further.