### PR TITLE
Standardize CI and test configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ source 'https://rubygems.org' do
   gem 'bundler', '>= 2.6', '< 5'
   gem 'debug', '>= 1.11', '< 2'
   gem 'minitest', '>= 5.27', '< 6'
-  gem 'minitest-reporters', '>= 1.7', '< 2'
+  gem 'minitest-reporters', '>= 1.8', '< 2'
   gem 'mysql2', '>= 0.5.7', '< 1'
   gem 'rake', '>= 13.3', '< 14'
   gem 'simplecov', '>= 0.22', '< 1', group: :test, require: false

--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,7 @@ require 'rake/testtask'
 Rake::TestTask.new(:test) do |t|
   t.libs << 'lib' << 'test'
   t.pattern = 'test/**/*_test.rb'
-  t.verbose = true
+  t.verbose = false
   t.warning = false
 end
 


### PR DESCRIPTION
## Summary
- Update `minitest-reporters` constraint to `>= 1.8, < 2`
- Set `Rake::TestTask` verbose to false

[BANK-2077](https://appfolio.atlassian.net/browse/BANK-2077)

[BANK-2077]: https://appfolio.atlassian.net/browse/BANK-2077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ