### PR TITLE
[BANK-2106] Migrate gem source from RubyGems to JFrog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   gem-tool: appfolio/gem-tool@volatile
+  public-packages: https://raw.githubusercontent.com/appfolio/public-packages/v1/orbs/public-packages.yml
 
 workflows:
   rc:
@@ -15,5 +16,7 @@ workflows:
                 - '4.0.1'
                 - '3.4.8'
                 - '3.3.10'
+          after-checkout-steps:
+            - public-packages/setup
           after-appraisal-install-steps:
             - gem-tool/wait_mysql

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,6 +5,11 @@ registries:
     type: rubygems-server
     url: https://rubygems.pkg.github.com/appfolio
     token: "${{secrets.READ_ONLY_PACKAGES_CCIMU}}"
+  public-rubygems-packages:
+    type: rubygems-server
+    url: https://appfolio.jfrog.io/artifactory/api/gems/appfolio-store_base_sti_class-gem/
+    jfrog-oidc-provider-name: appfolio-github-oidc
+    audience: jfrog-appfolio
 updates:
 - package-ecosystem: bundler
   directory: "/"

--- a/Appraisals
+++ b/Appraisals
@@ -2,19 +2,19 @@
 
 if Gem::Requirement.new(['>= 3.3', '< 4.1']).satisfied_by?(Gem::Version.new(RUBY_VERSION))
   appraise "ruby-#{RUBY_VERSION}_rails72" do
-    source 'https://rubygems.org' do
+    source 'https://appfolio.jfrog.io/artifactory/api/gems/appfolio-store_base_sti_class-gem/' do
       gem 'rails', '~> 7.2.0'
     end
   end
 
   appraise "ruby-#{RUBY_VERSION}_rails80" do
-    source 'https://rubygems.org' do
+    source 'https://appfolio.jfrog.io/artifactory/api/gems/appfolio-store_base_sti_class-gem/' do
       gem 'rails', '~> 8.0.0'
     end
   end
 
   appraise "ruby-#{RUBY_VERSION}_rails81" do
-    source 'https://rubygems.org' do
+    source 'https://appfolio.jfrog.io/artifactory/api/gems/appfolio-store_base_sti_class-gem/' do
       gem 'rails', '~> 8.1.0'
     end
   end

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org' # global source
+source 'https://appfolio.jfrog.io/artifactory/api/gems/appfolio-store_base_sti_class-gem/'
 
-source 'https://rubygems.org' do
+source 'https://appfolio.jfrog.io/artifactory/api/gems/appfolio-store_base_sti_class-gem/' do
   gem 'activesupport', '>= 7.2', '< 8.2'
   gem 'appraisal', '>= 2.5', '< 3'
   gem 'bundler', '>= 2.6', '< 5'


### PR DESCRIPTION
## Summary
Migrate Ruby gem source from rubygems.org to JFrog as part of org-wide JFrog migration.

## Changes
- Replaced `source 'https://rubygems.org'` with JFrog URL in Gemfile
- Replaced `source 'https://rubygems.org'` with JFrog URL in Appraisals
- Added `public-packages` orb and setup step to CircleCI config
- Added JFrog registry to Dependabot config
- Updated `allowed_push_host` in gemspec to JFrog URL
- Updated `package-location` in catalog-info.yaml to JFrog URL

## Why
AppFolio is migrating from RubyGems.org to JFrog for Ruby dependency installation.
Jira Issue: https://appfolio.atlassian.net/browse/BANK-2106

## Test Plan
- CI passes with the new gem source configuration